### PR TITLE
feat : 채팅 내용 화면 노출 구현

### DIFF
--- a/src/components/EnterChat.tsx
+++ b/src/components/EnterChat.tsx
@@ -1,0 +1,205 @@
+import { Fragment, useState } from "react";
+import {
+  FaceFrownIcon,
+  FaceSmileIcon,
+  FireIcon,
+  HandThumbUpIcon,
+  HeartIcon,
+  PaperClipIcon,
+  XMarkIcon,
+} from "@heroicons/react/20/solid";
+import { Listbox, Transition } from "@headlessui/react";
+
+const moods = [
+  {
+    name: "Excited",
+    value: "excited",
+    icon: FireIcon,
+    iconColor: "text-white",
+    bgColor: "bg-red-500",
+  },
+  {
+    name: "Loved",
+    value: "loved",
+    icon: HeartIcon,
+    iconColor: "text-white",
+    bgColor: "bg-pink-400",
+  },
+  {
+    name: "Happy",
+    value: "happy",
+    icon: FaceSmileIcon,
+    iconColor: "text-white",
+    bgColor: "bg-green-400",
+  },
+  {
+    name: "Sad",
+    value: "sad",
+    icon: FaceFrownIcon,
+    iconColor: "text-white",
+    bgColor: "bg-yellow-400",
+  },
+  {
+    name: "Thumbsy",
+    value: "thumbsy",
+    icon: HandThumbUpIcon,
+    iconColor: "text-white",
+    bgColor: "bg-blue-500",
+  },
+  {
+    name: "I feel nothing",
+    value: null,
+    icon: XMarkIcon,
+    iconColor: "text-gray-400",
+    bgColor: "bg-transparent",
+  },
+];
+
+function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export default function EnterChat() {
+  const [selected, setSelected] = useState(moods[5]);
+
+  return (
+    <div className="flex items-start space-x-4">
+      <div className="flex-shrink-0">
+        <img
+          className="inline-block h-10 w-10 rounded-full"
+          src="https://images.unsplash.com/photo-1550525811-e5869dd03032?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+          alt=""
+        />
+      </div>
+      <div className="min-w-0 flex-1">
+        <form action="#" className="relative">
+          <div className="overflow-hidden rounded-lg shadow-sm ring-1 ring-inset ring-gray-300 focus-within:ring-2 focus-within:ring-indigo-600">
+            <label htmlFor="comment" className="sr-only">
+              Add your comment
+            </label>
+            <textarea
+              rows={3}
+              name="comment"
+              id="comment"
+              className="block w-full resize-none border-0 bg-transparent py-1.5 text-gray-900 placeholder:text-gray-400 focus:ring-0 sm:text-sm sm:leading-6"
+              placeholder="Add your comment..."
+              defaultValue={""}
+            />
+
+            <div className="py-2" aria-hidden="true">
+              <div className="py-px">
+                <div className="h-9" />
+              </div>
+            </div>
+          </div>
+
+          <div className="absolute inset-x-0 bottom-0 flex justify-between py-2 pl-3 pr-2">
+            <div className="flex items-center space-x-5">
+              <div className="flex items-center">
+                <button
+                  type="button"
+                  className="-m-2.5 flex h-10 w-10 items-center justify-center rounded-full text-gray-400 hover:text-gray-500"
+                >
+                  <PaperClipIcon className="h-5 w-5" aria-hidden="true" />
+                  <span className="sr-only">Attach a file</span>
+                </button>
+              </div>
+              <div className="flex items-center">
+                <Listbox value={selected} onChange={setSelected}>
+                  {({ open }) => (
+                    <>
+                      <Listbox.Label className="sr-only">
+                        Your mood
+                      </Listbox.Label>
+                      <div className="relative">
+                        <Listbox.Button className="relative -m-2.5 flex h-10 w-10 items-center justify-center rounded-full text-gray-400 hover:text-gray-500">
+                          <span className="flex items-center justify-center">
+                            {selected.value === null ? (
+                              <span>
+                                <FaceSmileIcon
+                                  className="h-5 w-5 flex-shrink-0"
+                                  aria-hidden="true"
+                                />
+                                <span className="sr-only">Add your mood</span>
+                              </span>
+                            ) : (
+                              <span>
+                                <span
+                                  className={classNames(
+                                    selected.bgColor,
+                                    "flex h-8 w-8 items-center justify-center rounded-full"
+                                  )}
+                                >
+                                  <selected.icon
+                                    className="h-5 w-5 flex-shrink-0 text-white"
+                                    aria-hidden="true"
+                                  />
+                                </span>
+                                <span className="sr-only">{selected.name}</span>
+                              </span>
+                            )}
+                          </span>
+                        </Listbox.Button>
+
+                        <Transition
+                          show={open}
+                          as={Fragment}
+                          leave="transition ease-in duration-100"
+                          leaveFrom="opacity-100"
+                          leaveTo="opacity-0"
+                        >
+                          <Listbox.Options className="absolute z-10 -ml-6 mt-1 w-60 rounded-lg bg-white py-3 text-base shadow ring-1 ring-black ring-opacity-5 focus:outline-none sm:ml-auto sm:w-64 sm:text-sm">
+                            {moods.map((mood) => (
+                              <Listbox.Option
+                                key={mood.value}
+                                className={({ active }) =>
+                                  classNames(
+                                    active ? "bg-gray-100" : "bg-white",
+                                    "relative cursor-default select-none px-3 py-2"
+                                  )
+                                }
+                                value={mood}
+                              >
+                                <div className="flex items-center">
+                                  <div
+                                    className={classNames(
+                                      mood.bgColor,
+                                      "flex h-8 w-8 items-center justify-center rounded-full"
+                                    )}
+                                  >
+                                    <mood.icon
+                                      className={classNames(
+                                        mood.iconColor,
+                                        "h-5 w-5 flex-shrink-0"
+                                      )}
+                                      aria-hidden="true"
+                                    />
+                                  </div>
+                                  <span className="ml-3 block truncate font-medium">
+                                    {mood.name}
+                                  </span>
+                                </div>
+                              </Listbox.Option>
+                            ))}
+                          </Listbox.Options>
+                        </Transition>
+                      </div>
+                    </>
+                  )}
+                </Listbox>
+              </div>
+            </div>
+            <div className="flex-shrink-0">
+              <button
+                type="submit"
+                className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+              >
+                Post
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -1,14 +1,55 @@
-import { useEffect, useState } from "react";
-import { io } from "socket.io-client";
+import { useEffect, useRef, useState } from "react";
+import { Socket, io } from "socket.io-client";
 import { useLocation } from "react-router-dom";
-import { PaperClipIcon } from "@heroicons/react/20/solid";
 
 const Chat: React.FC = () => {
-  const [socket, setSocket] = useState("");
+  const socketRef = useRef<Socket | null>(null);
   const location = useLocation();
   const chatData = { ...location.state };
+  const [message, setMessage] = useState("");
+  const [chatMessages, setChatMessages] = useState<string[]>([]);
 
-  useEffect(() => {}, []);
+  console.log(chatData);
+
+  useEffect(() => {
+    // 소켓 인스턴스가 이미 존재하지 않는 경우에만 초기화
+    if (!socketRef.current) {
+      socketRef.current = io("ws://localhost:80/chat", {
+        transports: ["websocket"],
+      });
+
+      socketRef.current.on("hello_from_server", (message: string) => {
+        socketRef.current?.emit("enter_chat", chatData);
+      });
+
+      socketRef.current.on("receive_message", (message: string) => {
+        console.log(message);
+        setChatMessages((prevMessages) => [...prevMessages, message]); // 새 메시지를 상태에 추가s
+      });
+    }
+
+    return () => {
+      if (socketRef.current && socketRef.current.connected) {
+        socketRef.current.disconnect();
+        alert("소켓 연결을 해제합니다.");
+      }
+    };
+  }, []);
+
+  if (!socketRef) {
+    // 만약 소켓이 초기화되지 않았다면 로딩 상태를 렌더링하거나 UI에서 처리
+    return <div>로딩 중...</div>;
+  }
+
+  const sendMessage = () => {
+    if (socketRef.current) {
+      socketRef.current.emit("send_message", {
+        channel: chatData.channel,
+        message,
+      });
+      setMessage("");
+    }
+  };
 
   return (
     <div>
@@ -52,6 +93,40 @@ const Chat: React.FC = () => {
             </dd>
           </div>
         </dl>
+      </div>
+      {/* 메시지 표시 영역 */}
+      <div className="mt-6 bg-white border border-gray-300 p-4">
+        {chatMessages.map((msg, index) => (
+          <div key={index} className="p-2 border-b border-gray-200">
+            {msg}
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <label
+          htmlFor="comment"
+          className="block text-sm font-medium leading-6 text-gray-900"
+        >
+          Add your comment
+        </label>
+        <div className="mt-2">
+          <textarea
+            rows={4}
+            // name="comment"
+            // id="comment"
+            className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={sendMessage}
+          className="rounded bg-white px-2 py-1 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+        >
+          전송
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## What is this PR? 🔍
백엔드에서 구현한 채팅 기능을 확인하기 위한 프론트의 최소한의 구현 내용

## Changes 📝
- `entreChat` 컴포넌트 구현
- `Chat` 채팅 내용 구현

## Screenshot📸
![채팅 연결](https://github.com/vipwhy12/play-with-me-frontend/assets/85014628/4c072dc3-7ed2-4e23-bede-4895f337e38f)

## CheckList ✅
- 외부에서 전송한 내용이 화면에 보여지는가 
- 자신이 보낸 채팅 내용이 화면에 보여지는가 

## ETC
채팅방 화면에 대해 아래와 같은 추가적인 작업사항이 필요합니다. 
- [ ]  유저는 자신의 메세지와 같은 방에 있는 팀원을 화면으로 구분할 수 있다.
- [ ]  유저는 전송한 메세지의 주체를 알 수 있다.
- [ ]  유저는 전송한 주체의 프로필을 확인할 수 있다.